### PR TITLE
Bump prost-build to 0.10 to solve protobuf version incompatibility

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,6 +21,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Install latest protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install sdist-only dependencies
       if: ${{ matrix.type == 'sdist' }}
       uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,7 +807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.9.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes",
+ "prost-derive 0.10.1",
 ]
 
 [[package]]
@@ -814,8 +833,30 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.9.0",
+ "prost-types 0.9.0",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "cmake",
+ "heck 0.4.0",
+ "itertools 0.10.3",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "regex",
  "tempfile",
  "which",
@@ -835,13 +876,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.9.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost 0.10.4",
 ]
 
 [[package]]
@@ -937,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -948,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -1086,9 +1150,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "percent-encoding",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.10.4",
+ "prost-build 0.10.4",
+ "prost-types 0.10.1",
  "regex",
  "serde_json",
  "strum",
@@ -1125,7 +1189,7 @@ name = "substrait-validator-py"
 version = "0.0.1"
 dependencies = [
  "dunce",
- "prost-build",
+ "prost-build 0.9.0",
  "pyo3",
  "substrait-validator",
  "walkdir",
@@ -1161,7 +1225,7 @@ name = "test-runner"
 version = "0.0.1"
 dependencies = [
  "glob",
- "prost-build",
+ "prost-build 0.10.4",
  "rayon",
  "serde",
  "serde_json",

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -33,6 +33,6 @@ substrait-validator = { path = "../rs", version = "0.0.1" }
 pyo3 = { version = "0.15.1", features = ["extension-module"] }
 
 [build-dependencies]
-prost-build = "0.9"
+prost-build = "0.10"
 walkdir = "2"
 dunce = "1"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -12,8 +12,8 @@ include = ["src", "build.rs", "README.md"]
 [dependencies]
 
 # Prost is used to deal with protobuf serialization and deserialization.
-prost = "0.9"
-prost-types = "0.9"
+prost = "0.10"
+prost-types = "0.10"
 
 # Prost doesn't generate any introspection stuff, so we hack that stuff in with
 # our own procedural macros.
@@ -80,7 +80,7 @@ percent-encoding = "2.1"
 [build-dependencies]
 
 # Used for generating Rust structs from the protobuf definitions.
-prost-build = "0.9"
+prost-build = "0.10"
 
 # Used to automatically find all protobuf files.
 walkdir = "2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2"
 glob = "0.3"
-prost-build = "0.9"
+prost-build = "0.10"
 rayon = "1.5"


### PR DESCRIPTION
Should help solve the issue described [here](https://github.com/protocolbuffers/protobuf/issues/10051) and [here](https://github.com/substrait-io/substrait-validator/pull/1#issuecomment-1138438397) by effectively upgrading protoc from 3.15.8 to 3.19.4. However, from now on either protoc needs to already be installed on the system to install, or prost-build needs to have the tools available to build it from source (needs CMake an C++ toolchain).

~~ETA: Rerunning CI on my fork shows that this has actually broken again for no apparent reason, turning into draft.~~ forgot to increment one of instances of the dependency, no idea how it ever passed before this :shrug: