### PR TITLE
chore: backport minor fixes and refactorings from abandoned branch

### DIFF
--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -32,7 +32,7 @@ mod parse;
 pub mod export;
 pub mod input;
 
-mod string_util;
+mod util;
 
 use strum::IntoEnumIterator;
 

--- a/rs/src/output/data_type.rs
+++ b/rs/src/output/data_type.rs
@@ -6,8 +6,8 @@
 
 use crate::output::diagnostic;
 use crate::output::extension;
-use crate::string_util;
-use crate::string_util::Describe;
+use crate::util;
+use crate::util::string::Describe;
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -37,7 +37,7 @@ impl Describe for DataType {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         let mut name = String::new();
         write!(&mut name, "{}", self.class)?;
@@ -51,7 +51,7 @@ impl Describe for DataType {
         let (_, limit) = limit.split(name.len());
         if self.class.has_parameters() {
             write!(f, "<")?;
-            string_util::describe_sequence(
+            util::string::describe_sequence(
                 f,
                 &self.parameters,
                 limit,
@@ -473,7 +473,7 @@ pub trait ParameterInfo {
 }
 
 /// Type class.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Class {
     /// Well-known simple type.
     Simple(Simple),
@@ -556,7 +556,7 @@ impl Class {
 }
 
 /// Enumeration of simple types defined by Substrait.
-#[derive(Clone, Debug, PartialEq, Display, EnumString)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Display, EnumString)]
 #[strum(ascii_case_insensitive, serialize_all = "snake_case")]
 pub enum Simple {
     Boolean,
@@ -578,7 +578,7 @@ pub enum Simple {
 }
 
 /// Enumeration of compound types defined by Substrait.
-#[derive(Clone, Debug, PartialEq, Display, EnumString)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Display, EnumString)]
 #[strum(ascii_case_insensitive, serialize_all = "UPPERCASE")]
 pub enum Compound {
     FixedChar,
@@ -762,13 +762,13 @@ impl Describe for Parameter {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         match self {
             Parameter::Type(data_type) => data_type.describe(f, limit),
             Parameter::NamedType(name, data_type) => {
                 let (name_limit, type_limit) = limit.split(name.len());
-                string_util::describe_identifier(f, name, name_limit)?;
+                util::string::describe_identifier(f, name, name_limit)?;
                 write!(f, ": ")?;
                 data_type.describe(f, type_limit)
             }

--- a/rs/src/output/diagnostic.rs
+++ b/rs/src/output/diagnostic.rs
@@ -187,7 +187,7 @@ pub enum Classification {
     #[strum(props(Description = "missing protobuf \"any\" declaration"))]
     ProtoMissingAnyDeclaration = 1006,
 
-    // YAML-reated diagnostics (group 2).
+    // YAML-related diagnostics (group 2).
     #[strum(props(HiddenDescription = "YAML-related diagnostic"))]
     Yaml = 2000,
 

--- a/rs/src/output/extension.rs
+++ b/rs/src/output/extension.rs
@@ -5,7 +5,7 @@
 use crate::output::data_type;
 use crate::output::path;
 use crate::output::tree;
-use crate::string_util;
+use crate::util;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -21,19 +21,23 @@ pub struct NamedReference {
 }
 
 impl PartialEq for NamedReference {
-    /// Named references are equal if both references have a known name and
-    /// those names are the same.
     fn eq(&self, other: &Self) -> bool {
-        self.name.is_some() && other.name.is_some() && self.name == other.name
+        self.name == other.name
     }
 }
 
 impl Eq for NamedReference {}
 
+impl std::hash::Hash for NamedReference {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
 impl std::fmt::Display for NamedReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(name) = &self.name {
-            write!(f, "{}", string_util::as_ident_or_string(name))
+            write!(f, "{}", util::string::as_ident_or_string(name))
         } else {
             write!(f, "?")
         }
@@ -92,7 +96,7 @@ pub struct Reference<T> {
 
 impl<T> PartialEq for Reference<T> {
     /// References are equal if they refer to the same thing, regardless of how
-    /// they refer to it. If we're not sure4 because either reference is
+    /// they refer to it. If we're not sure because either reference is
     /// (partially) unresolved, return false pessimistically.
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.uri == other.uri
@@ -100,6 +104,13 @@ impl<T> PartialEq for Reference<T> {
 }
 
 impl<T> Eq for Reference<T> {}
+
+impl<T> std::hash::Hash for Reference<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.uri.hash(state);
+    }
+}
 
 impl<T> std::fmt::Display for Reference<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/rs/src/output/path.rs
+++ b/rs/src/output/path.rs
@@ -8,7 +8,7 @@
 //! roughly the same as [`std::path::Path`], and [`std::path::PathBuf`], but
 //! for protobuf/YAML tree paths rather than filesystem paths.
 
-use crate::string_util;
+use crate::util;
 
 /// Element of a path to some field of a protobuf message and/or YAML file.
 #[derive(Clone, Debug, PartialEq)]
@@ -39,15 +39,15 @@ impl std::fmt::Display for PathElement {
             }
         }
         match self {
-            PathElement::Field(field) => write!(f, "{}", string_util::as_ident_or_string(field)),
+            PathElement::Field(field) => write!(f, "{}", util::string::as_ident_or_string(field)),
             PathElement::Repeated(field, index) => {
-                write!(f, "{}[{index}]", string_util::as_ident_or_string(field))
+                write!(f, "{}[{index}]", util::string::as_ident_or_string(field))
             }
             PathElement::Variant(field, variant) => write!(
                 f,
                 "{}<{}>",
-                string_util::as_ident_or_string(field),
-                string_util::as_ident_or_string(variant)
+                util::string::as_ident_or_string(field),
+                util::string::as_ident_or_string(variant)
             ),
             PathElement::Index(index) => write!(f, "[{index}]"),
         }

--- a/rs/src/parse/expressions/literals.rs
+++ b/rs/src/parse/expressions/literals.rs
@@ -7,8 +7,8 @@ use crate::output::data_type;
 use crate::output::diagnostic;
 use crate::parse::context;
 use crate::parse::types;
-use crate::string_util;
-use crate::string_util::Describe;
+use crate::util;
+use crate::util::string::Describe;
 use std::sync::Arc;
 
 /// The value of a literal, not including type information.
@@ -136,7 +136,7 @@ impl Describe for Literal {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         match &self.value {
             LiteralValue::Null => {
@@ -197,7 +197,7 @@ impl Describe for Literal {
                         }
                         Ok(())
                     } else {
-                        string_util::describe_binary(f, &d.to_le_bytes(), limit)
+                        util::string::describe_binary(f, &d.to_le_bytes(), limit)
                     }
                 }
                 data_type::Class::Simple(data_type::Simple::Uuid) => {
@@ -208,10 +208,10 @@ impl Describe for Literal {
                         b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]
                     )
                 }
-                _ => string_util::describe_binary(f, &d.to_le_bytes(), limit),
+                _ => util::string::describe_binary(f, &d.to_le_bytes(), limit),
             },
-            LiteralValue::String(s) => string_util::describe_string(f, s, limit),
-            LiteralValue::Binary(b) => string_util::describe_binary(f, b, limit),
+            LiteralValue::String(s) => util::string::describe_string(f, s, limit),
+            LiteralValue::Binary(b) => util::string::describe_binary(f, b, limit),
             LiteralValue::Interval(a, b) => match self.data_type.class() {
                 data_type::Class::Simple(data_type::Simple::IntervalYear) => {
                     write!(f, "{a}y{b:+}m")
@@ -222,7 +222,7 @@ impl Describe for Literal {
             LiteralValue::Items(x) => match self.data_type.class() {
                 data_type::Class::Compound(data_type::Compound::Struct) => {
                     write!(f, "(")?;
-                    string_util::describe_sequence(f, x, limit, 20, |f, value, index, limit| {
+                    util::string::describe_sequence(f, x, limit, 20, |f, value, index, limit| {
                         write!(f, ".{index}: ")?;
                         value.describe(f, limit)
                     })?;
@@ -230,14 +230,14 @@ impl Describe for Literal {
                 }
                 data_type::Class::Compound(data_type::Compound::NamedStruct) => {
                     write!(f, "(")?;
-                    string_util::describe_sequence(f, x, limit, 20, |f, value, index, limit| {
+                    util::string::describe_sequence(f, x, limit, 20, |f, value, index, limit| {
                         if let Some(name) = self
                             .data_type
                             .parameters()
                             .get(index)
                             .and_then(|x| x.get_name())
                         {
-                            write!(f, ".{}: ", string_util::as_ident_or_string(name))?;
+                            write!(f, ".{}: ", util::string::as_ident_or_string(name))?;
                         } else {
                             write!(f, ".{index}: ")?;
                         }
@@ -247,14 +247,14 @@ impl Describe for Literal {
                 }
                 data_type::Class::Compound(data_type::Compound::List) => {
                     write!(f, "[")?;
-                    string_util::describe_sequence(f, x, limit, 20, |f, value, _, limit| {
+                    util::string::describe_sequence(f, x, limit, 20, |f, value, _, limit| {
                         value.describe(f, limit)
                     })?;
                     write!(f, "]")
                 }
                 _ => {
                     write!(f, "(")?;
-                    string_util::describe_sequence(f, x, limit, 20, |f, value, _, limit| {
+                    util::string::describe_sequence(f, x, limit, 20, |f, value, _, limit| {
                         value.describe(f, limit)
                     })?;
                     write!(f, ")")
@@ -263,7 +263,7 @@ impl Describe for Literal {
             LiteralValue::Pairs(x) => match self.data_type.class() {
                 data_type::Class::Compound(data_type::Compound::Map) => {
                     write!(f, "{{")?;
-                    string_util::describe_sequence(
+                    util::string::describe_sequence(
                         f,
                         x,
                         limit,
@@ -279,7 +279,7 @@ impl Describe for Literal {
                 }
                 _ => {
                     write!(f, "(")?;
-                    string_util::describe_sequence(
+                    util::string::describe_sequence(
                         f,
                         x,
                         limit,

--- a/rs/src/parse/expressions/misc.rs
+++ b/rs/src/parse/expressions/misc.rs
@@ -7,7 +7,7 @@ use crate::output::diagnostic;
 use crate::parse::context;
 use crate::parse::expressions;
 use crate::parse::types;
-use crate::string_util;
+use crate::util;
 
 /// Parse an enum expression. Returns a description of said expression.
 pub fn parse_enum(
@@ -35,7 +35,7 @@ pub fn parse_enum(
             y,
             Misc,
             "Function option variant {}",
-            string_util::as_ident_or_string(variant)
+            util::string::as_ident_or_string(variant)
         );
     } else {
         describe!(y, Misc, "Default function option variant");

--- a/rs/src/parse/expressions/mod.rs
+++ b/rs/src/parse/expressions/mod.rs
@@ -6,8 +6,8 @@ use crate::input::proto::substrait;
 use crate::output::data_type;
 use crate::output::diagnostic;
 use crate::parse::context;
-use crate::string_util;
-use crate::string_util::Describe;
+use crate::util;
+use crate::util::string::Describe;
 use std::sync::Arc;
 
 pub mod conditionals;
@@ -72,7 +72,7 @@ impl Describe for Expression {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         match self {
             Expression::Unresolved => write!(f, "?"),
@@ -80,17 +80,17 @@ impl Describe for Expression {
             Expression::Reference(x) => x.describe(f, limit),
             Expression::Function(name, args) => {
                 let (name_limit, args_limit) = limit.split(name.len());
-                string_util::describe_identifier(f, name, name_limit)?;
+                util::string::describe_identifier(f, name, name_limit)?;
                 write!(f, "(")?;
-                string_util::describe_sequence(f, args, args_limit, 20, |f, expr, _, limit| {
+                util::string::describe_sequence(f, args, args_limit, 20, |f, expr, _, limit| {
                     expr.describe(f, limit)
                 })?;
                 write!(f, ")")
             }
-            Expression::BigFunction(name) => string_util::describe_identifier(f, name, limit),
+            Expression::BigFunction(name) => util::string::describe_identifier(f, name, limit),
             Expression::Tuple(items) => {
                 write!(f, "(")?;
-                string_util::describe_sequence(f, items, limit, 20, |f, expr, _, limit| {
+                util::string::describe_sequence(f, items, limit, 20, |f, expr, _, limit| {
                     expr.describe(f, limit)
                 })?;
                 write!(f, ")")
@@ -103,7 +103,7 @@ impl Describe for Expression {
                 expression.describe(f, expr_limit)?;
                 write!(f, ")")
             }
-            Expression::EnumVariant(Some(x)) => string_util::describe_identifier(f, x, limit),
+            Expression::EnumVariant(Some(x)) => util::string::describe_identifier(f, x, limit),
             Expression::EnumVariant(None) => write!(f, "-"),
         }
     }

--- a/rs/src/parse/expressions/references/mask.rs
+++ b/rs/src/parse/expressions/references/mask.rs
@@ -6,7 +6,7 @@ use crate::input::proto::substrait;
 use crate::output::data_type;
 use crate::output::diagnostic;
 use crate::parse::context;
-use crate::string_util;
+use crate::util;
 use std::sync::Arc;
 
 /// Parse a struct item.
@@ -91,7 +91,7 @@ fn parse_list_select_item_element(
         y,
         Expression,
         "Select {} element",
-        string_util::describe_index(x.field)
+        util::string::describe_index(x.field)
     );
     Ok(())
 }
@@ -127,8 +127,8 @@ fn parse_list_select_item_slice(
     } else {
         format!(
             "Select {} until {} element (inclusive)",
-            string_util::describe_index(x.start),
-            string_util::describe_index(x.end)
+            util::string::describe_index(x.start),
+            util::string::describe_index(x.end)
         )
     };
     describe!(y, Expression, "{}", description);

--- a/rs/src/parse/expressions/references/mod.rs
+++ b/rs/src/parse/expressions/references/mod.rs
@@ -8,8 +8,8 @@ use crate::output::data_type;
 use crate::output::diagnostic;
 use crate::parse::context;
 use crate::parse::expressions;
-use crate::string_util;
-use crate::string_util::Describe;
+use crate::util;
+use crate::util::string::Describe;
 use std::sync::Arc;
 
 pub mod mask;
@@ -70,7 +70,7 @@ impl Describe for ReferencePath {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         let lens = self.segments.iter().map(String::len).collect::<Vec<_>>();
         let (n_left, n_right) = limit.split_ns(&lens);
@@ -113,7 +113,7 @@ impl Describe for Reference {
     fn describe(
         &self,
         f: &mut std::fmt::Formatter<'_>,
-        limit: string_util::Limit,
+        limit: util::string::Limit,
     ) -> std::fmt::Result {
         let (path_limit, root_limit) = limit.split(self.path.len());
         match &self.root {
@@ -178,7 +178,7 @@ fn parse_root_type(
                 y,
                 Misc,
                 "Reference to field of {} outer query",
-                string_util::describe_nth(x.steps_out)
+                util::string::describe_nth(x.steps_out)
             );
             proto_primitive_field!(x, y, steps_out, |x, y| {
                 if *x < 1 {
@@ -254,7 +254,7 @@ pub fn parse_field_reference(
                 y,
                 "Here, <{depth}> is used to refer to the row being processed \
                 by the {} outer query.",
-                string_util::describe_nth(depth as u32)
+                util::string::describe_nth(depth as u32)
             );
         }
     }

--- a/rs/src/parse/expressions/references/scalar.rs
+++ b/rs/src/parse/expressions/references/scalar.rs
@@ -9,7 +9,7 @@ use crate::parse::context;
 use crate::parse::expressions::literals;
 use crate::parse::expressions::references;
 use crate::parse::types;
-use crate::string_util;
+use crate::util;
 use std::sync::Arc;
 
 /// Parse a struct field reference. Returns a description of the nested
@@ -93,7 +93,7 @@ fn parse_list_element(
             y,
             Misc,
             "Selects {} list element",
-            string_util::describe_index(*x)
+            util::string::describe_index(*x)
         );
         Ok(())
     });

--- a/rs/src/parse/extensions/simple/yaml.rs
+++ b/rs/src/parse/extensions/simple/yaml.rs
@@ -12,7 +12,7 @@ use crate::parse::extensions::simple::function_decls;
 use crate::parse::extensions::simple::type_decls;
 use crate::parse::extensions::simple::type_variation_decls;
 use crate::parse::traversal;
-use crate::string_util;
+use crate::util;
 use std::sync::Arc;
 
 /// Toplevel parse function for a simple extension YAML file.
@@ -46,7 +46,7 @@ pub fn parse_uri<S: AsRef<str>>(
 ) -> Result<Arc<extension::YamlInfo>> {
     // Check URI syntax.
     let x = x.as_ref();
-    if let Err(e) = string_util::check_uri(x) {
+    if let Err(e) = util::string::check_uri(x) {
         diagnostic!(y, Error, e);
     }
 

--- a/rs/src/parse/relations/fetch.rs
+++ b/rs/src/parse/relations/fetch.rs
@@ -10,7 +10,7 @@
 use crate::input::proto::substrait;
 use crate::output::diagnostic;
 use crate::parse::context;
-use crate::string_util;
+use crate::util;
 
 /// Parse fetch relation.
 pub fn parse_fetch_rel(
@@ -45,7 +45,7 @@ pub fn parse_fetch_rel(
             "Propagate only the {} row",
             (x.offset + 1)
                 .try_into()
-                .map(string_util::describe_nth)
+                .map(util::string::describe_nth)
                 .unwrap_or_else(|_| String::from("?"))
         );
     } else if x.count > 1 {
@@ -57,7 +57,7 @@ pub fn parse_fetch_rel(
                 x.count,
                 (x.offset + 1)
                     .try_into()
-                    .map(string_util::describe_nth)
+                    .map(util::string::describe_nth)
                     .unwrap_or_else(|_| String::from("?"))
             );
         } else {

--- a/rs/src/parse/relations/read.rs
+++ b/rs/src/parse/relations/read.rs
@@ -18,7 +18,7 @@ use crate::parse::expressions::literals;
 use crate::parse::expressions::references::mask;
 use crate::parse::extensions;
 use crate::parse::types;
-use crate::string_util;
+use crate::util;
 
 /// Information about a data source.
 struct SourceInfo {
@@ -75,25 +75,25 @@ fn parse_path_type(
     use substrait::read_rel::local_files::file_or_files::PathType;
     match x {
         PathType::UriPath(x) => {
-            if let Err(e) = string_util::check_uri(x) {
+            if let Err(e) = util::string::check_uri(x) {
                 diagnostic!(y, Error, e);
             }
             Ok(false)
         }
         PathType::UriPathGlob(x) => {
-            if let Err(e) = string_util::check_uri_glob(x) {
+            if let Err(e) = util::string::check_uri_glob(x) {
                 diagnostic!(y, Error, e);
             }
             Ok(true)
         }
         PathType::UriFile(x) => {
-            if let Err(e) = string_util::check_uri(x) {
+            if let Err(e) = util::string::check_uri(x) {
                 diagnostic!(y, Error, e);
             }
             Ok(false)
         }
         PathType::UriFolder(x) => {
-            if let Err(e) = string_util::check_uri(x) {
+            if let Err(e) = util::string::check_uri(x) {
                 diagnostic!(y, Error, e);
             }
             Ok(true)
@@ -253,7 +253,7 @@ fn parse_named_table(
                 "named tables with multiple names"
             );
         }
-        string_util::as_ident_or_string(x.names.first().unwrap())
+        util::string::as_ident_or_string(x.names.first().unwrap())
     };
 
     // Describe the node.
@@ -261,7 +261,7 @@ fn parse_named_table(
         y,
         Misc,
         "Named table {}",
-        string_util::as_ident_or_string(&name)
+        util::string::as_ident_or_string(&name)
     );
     Ok(SourceInfo {
         name,

--- a/rs/src/parse/types.rs
+++ b/rs/src/parse/types.rs
@@ -12,7 +12,7 @@ use crate::output::diagnostic;
 use crate::output::extension;
 use crate::parse::context;
 use crate::parse::extensions;
-use crate::string_util;
+use crate::util;
 
 /// Parses a required nullability enum.
 fn parse_required_nullability(
@@ -799,7 +799,7 @@ fn describe_type(y: &mut context::Context, data_type: &Arc<data_type::DataType>)
                     } else {
                         y.push_summary(comment::Comment::new().li());
                     }
-                    summary!(y, "{}: {}", string_util::as_ident_or_string(name), class);
+                    summary!(y, "{}: {}", util::string::as_ident_or_string(name), class);
                 }
                 y.push_summary(comment::Comment::new().lc());
             }
@@ -1078,8 +1078,8 @@ fn assert_equal_internal(
                                 Warning,
                                 TypeMismatch,
                                 "{message}: field name {} vs. {}{path}",
-                                string_util::as_ident_or_string(&other_name),
-                                string_util::as_ident_or_string(&base_name)
+                                util::string::as_ident_or_string(&other_name),
+                                util::string::as_ident_or_string(&base_name)
                             );
                         }
                         data_type::Parameter::NamedType(

--- a/rs/src/util/mod.rs
+++ b/rs/src/util/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains utilities that don't really belong in another more
+//! specific toplevel module.
+
+pub mod string;

--- a/rs/src/util/string.rs
+++ b/rs/src/util/string.rs
@@ -4,10 +4,16 @@
 
 use crate::output::diagnostic;
 
-/// Returns whether the given string is a valid identifier.
+/// Returns whether the given string is a valid identifier. Note: this should
+/// only be used for determining whether to print something that should be
+/// identifier-like with or without quotes and escape characters, as it is
+/// rather lax.
 pub fn is_identifier(s: &str) -> bool {
+    // Note:
+    //  - $ seems to be legal in type names;
+    //  - ! and : are used within function names/signatures.
     static IDENTIFIER_RE: once_cell::sync::Lazy<regex::Regex> =
-        once_cell::sync::Lazy::new(|| regex::Regex::new("[a-zA-Z_][a-zA-Z0-9_]*").unwrap());
+        once_cell::sync::Lazy::new(|| regex::Regex::new("[a-zA-Z_$][a-zA-Z0-9_$!:]*").unwrap());
     IDENTIFIER_RE.is_match(s)
 }
 
@@ -52,7 +58,7 @@ pub fn as_quoted_string<S: AsRef<str>>(s: S) -> String {
 }
 
 /// Returns the given string as-is if it's a valid identifier (i.e. if it
-/// matches `[a-zA-Z_][a-zA-Z0-9_]*`), or returns it as an escaped string
+/// matches `[a-zA-Z_$][a-zA-Z0-9_$!:]*`), or returns it as an escaped string
 /// otherwise, using (only) \" and \\ as escape sequences.
 pub fn as_ident_or_string<S: AsRef<str>>(s: S) -> String {
     let s = s.as_ref();


### PR DESCRIPTION
Changes:

 - Refactor `string_util` to `util::string`. Better to do it sooner than later, even though the `string` module is the only child of `util` right now. Signals intent that `util` is where all misc things that are not necessarily specific to the validator should go.
 - Implement some `Eq`/`Hash` traits.
 - Extend the syntax for what the validator considers to be an identifier in accordance with the [ANTLR grammar](https://github.com/substrait-io/substrait-java/blob/main/core/src/main/antlr/SubstraitType.g4#L102) and `u!` [user-defined type prefix](https://substrait.io/extensions/#function-signature-compound-names) (the validator simply uses this to determine whether it should print something that *should* be a valid identifier with or without quotes in the HTML output).
 - Fix some typos in comments.

Abandoned branch being my third (I think) attempt at type expression support; it was getting way too complicated the way I was doing it.