### PR TITLE
chore: unpin clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,9 +78,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # Clippy 1.60 crashes on the codebase, see
-          # https://github.com/rust-lang/rust-clippy/issues/8527
-          toolchain: "1.59.0"
+          toolchain: stable
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1

--- a/rs/src/parse/expressions/literals.rs
+++ b/rs/src/parse/expressions/literals.rs
@@ -188,7 +188,7 @@ impl Describe for Literal {
                         if d < &0 {
                             write!(f, "-")?;
                         }
-                        let d = d.abs() as u128;
+                        let d = d.unsigned_abs();
                         let s = 10u128.pow(scale as u32);
                         if self
                             .data_type


### PR DESCRIPTION
Latest stable Clippy no longer throws ICE on codebase.