### PR TITLE
fix(CI): disable commitlint on push to main

### DIFF
--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -2,8 +2,6 @@ name: Misc
 
 on:
   pull_request:
-  push:
-    branches: [ main ]
 
 jobs:
   license:


### PR DESCRIPTION
The history of main contains all kinds of non-conforming messages,
so it screams bloody murder there. The other misc checks are also
disabled on push to main by this, but having them only run for a
PR is probably good enough anyway.