### PR TITLE
fix: add note to summary of read relation about filter

### DIFF
--- a/tests/tests/relations/read/filter-project/both.yaml
+++ b/tests/tests/relations/read/filter-project/both.yaml
@@ -1,26 +1,48 @@
 name: read-filter-project
 plan:
-  __test: [ level: i ]
+  __test: [level: i]
   relations:
-  - rel:
-      read:
-        baseSchema:
-          names: [a, b]
-          struct:
-            nullability: NULLABILITY_REQUIRED
-            types:
-            - string: { nullability: NULLABILITY_REQUIRED }
-            - bool: { nullability: NULLABILITY_REQUIRED }
-        namedTable:
-          names:
-          - test
-        filter:
-          selection:
-            rootReference: {}
-            directReference: { structField: { field: 1 } }
-        projection:
-          maintain_singular_struct: true
-          select:
-            structItems:
-            - field: 0
-        __test: [ type: "STRUCT<string>" ]
+    - rel:
+        read:
+          baseSchema:
+            names: [a, b]
+            struct:
+              nullability: NULLABILITY_REQUIRED
+              types:
+                - string: { nullability: NULLABILITY_REQUIRED }
+                - bool: { nullability: NULLABILITY_REQUIRED }
+          namedTable:
+            names:
+              - test
+          filter:
+            selection:
+              rootReference: {}
+              directReference: { structField: { field: 1 } }
+          projection:
+            maintain_singular_struct: true
+            select:
+              structItems:
+                - field: 0
+          __test: [comment: "*yields false.", type: "STRUCT<string>"]
+    - rel:
+        read:
+          baseSchema:
+            names: [a, b]
+            struct:
+              nullability: NULLABILITY_REQUIRED
+              types:
+                - string: { nullability: NULLABILITY_REQUIRED }
+                - bool: { nullability: NULLABILITY_NULLABLE }
+          namedTable:
+            names:
+              - test
+          filter:
+            selection:
+              rootReference: {}
+              directReference: { structField: { field: 1 } }
+          projection:
+            maintain_singular_struct: true
+            select:
+              structItems:
+                - field: 0
+          __test: [comment: "*yields false or null.", type: "STRUCT<string>"]

--- a/tests/tests/relations/read/filter-project/projection-multiple.yaml
+++ b/tests/tests/relations/read/filter-project/projection-multiple.yaml
@@ -1,22 +1,22 @@
 name: read-projection-multiple
 plan:
-  __test: [ level: i ]
+  __test: [level: i]
   relations:
-  - rel:
-      read:
-        baseSchema:
-          names: [a, b]
-          struct:
-            nullability: NULLABILITY_REQUIRED
-            types:
-            - string: { nullability: NULLABILITY_REQUIRED }
-            - bool: { nullability: NULLABILITY_REQUIRED }
-        namedTable:
-          names:
-          - test
-        projection:
-          select:
-            structItems:
-            - field: 1
-            - field: 0
-        __test: [ type: "STRUCT<boolean, string>" ]
+    - rel:
+        read:
+          baseSchema:
+            names: [a, b]
+            struct:
+              nullability: NULLABILITY_REQUIRED
+              types:
+                - string: { nullability: NULLABILITY_REQUIRED }
+                - bool: { nullability: NULLABILITY_REQUIRED }
+          namedTable:
+            names:
+              - test
+          projection:
+            select:
+              structItems:
+                - field: 1
+                - field: 0
+          __test: [comment: "", type: "STRUCT<boolean, string>"]


### PR DESCRIPTION
Part of #51. This adds a note (including nullability behavior) to the summary of read relations that have filter expressions.