### PR TITLE
chore: allow ptr_arg when handling protobufs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 gen
 /target/
 **/*.rs.bk
+*.iml

--- a/rs/src/parse/plan.rs
+++ b/rs/src/parse/plan.rs
@@ -2,6 +2,8 @@
 
 //! Module providing toplevel parse/validation functions for plans.
 
+#![allow(clippy::ptr_arg)]
+
 use crate::input::proto::substrait;
 use crate::output::diagnostic;
 use crate::output::type_system::data;


### PR DESCRIPTION
While it would be nice to fix this, the change requires a change to how protobuffers are handled which is not a minor change.  Filed #154 to track.