### PR TITLE
ci: remove `python 3.7`, add `python 3.12`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         type: [wheel]
         include:
           - os: ubuntu-latest
-            python-version: "3.7"
+            python-version: "3.8"
             type: sdist
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
       - uses: Swatinem/rust-cache@v2
       - name: Run unit tests
         run: cargo test --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,11 +34,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - uses: Swatinem/rust-cache@v2
       - name: Run unit tests
         run: cargo test --all-features
       - name: Install test runner dependencies
-        run: python3 -m pip install --upgrade pip protobuf pyyaml
+        run: python3 -m pip install --upgrade pip protobuf pyyaml click
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Run validation tests
         # No need to run validation tests for all operating systems, and Linux
         # runners are the fastest of the bunch.

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -10,24 +10,16 @@ description = "Validator for Substrait query plans"
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["substrait"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = [
-    "protobuf > 3.19.3",
-    "click >= 8",
-    "pyyaml >= 6",
-    "jdot >= 0.5"
-]
+dependencies = ["protobuf > 3.19.3", "click >= 8", "pyyaml >= 6", "jdot >= 0.5"]
 
 [project.optional-dependencies]
-test = [
-  "pytest < 9.0.0",
-  "toml >= 0.10.2"
-]
+test = ["pytest < 9.0.0", "toml >= 0.10.2"]
 
 [project.urls]
 homepage = "https://substrait.io/"


### PR DESCRIPTION
`3.7` is almost EOL and is no longer available on `macos-latest` runner images.