### PR TITLE
build: update dependencies

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Configure
         run: mkdir -p build && cd build && cmake ../c -DSUBSTRAIT_VALIDATOR_BUILD_TESTS=ON

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,10 +64,14 @@ jobs:
         uses: PyO3/maturin-action@v1.44.0
         with:
           manylinux: auto
-          # Don't use a docker container for building the wheels
-          container: off
           command: build
           args: -i ${{ matrix.python-version }} --release -o dist -m py/Cargo.toml
+          # Download protoc into the container, for use in the build
+          before-script-linux: |
+            PROTOC_VERSION=28.3
+            PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+            curl -LO $PB_REL/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip
+            unzip protoc-$PROTOC_VERSION-linux-x86_64.zip -d /usr/local
       - name: Build Windows wheels
         if: ${{ matrix.type == 'wheel' && matrix.os == 'windows-latest' }}
         uses: PyO3/maturin-action@v1.44.0

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install latest protoc
         uses: arduino/setup-protoc@v3
         with:
+          version: "28.3"
+          # avoid rate-limiting
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sdist-only dependencies
         if: ${{ matrix.type == 'sdist' }}
@@ -62,6 +64,8 @@ jobs:
         uses: PyO3/maturin-action@v1.44.0
         with:
           manylinux: auto
+          # Don't use a docker container for building the wheels
+          container: off
           command: build
           args: -i ${{ matrix.python-version }} --release -o dist -m py/Cargo.toml
       - name: Build Windows wheels

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check
@@ -30,6 +35,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v5
         with:
@@ -67,6 +77,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -81,6 +96,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Doc
@@ -96,6 +116,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "28.3"
+          # avoid rate-limiting
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Fetch Substrait submodule tags
         working-directory: substrait

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Here's a (probably non-exhaustive) list of things you may want to have installed
  - [pre-commit](https://pre-commit.com/), so you don't have to rely on CI to catch all your errors, and to help format your code
  - git (obviously)
  - for the C bindings: [CMake](https://cmake.org/) and a C compiler (gcc, clang, and MSVC should all work; the bindings are very lightweight)
+ - [Protobuf](https://protobuf.dev/overview/), namely the `protoc` executable, for working with Substrait
 
 Note: this list is probably non-exhaustive; if you find something missing from this list, please add it!
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "antlr-rust"
 version = "0.3.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,17 +111,6 @@ name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -145,19 +183,19 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cbindgen"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
  "clap",
  "heck 0.4.1",
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn",
  "tempfile",
  "toml",
 ]
@@ -193,36 +231,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "cmake"
-version = "0.1.51"
+name = "colorchoice"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
-]
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "core-foundation-sys"
@@ -397,12 +435,6 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
@@ -418,24 +450,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -472,22 +486,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -506,21 +510,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "iso8601"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -720,7 +721,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -788,12 +789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.6.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -882,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -896,44 +891,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
-dependencies = [
- "bytes",
- "prost-derive 0.10.1",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
- "prost-derive 0.13.3",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.10.4",
- "prost-types 0.10.1",
- "regex",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -944,30 +907,17 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.3",
- "prost-types 0.13.3",
+ "prost",
+ "prost-types",
  "regex",
- "syn 2.0.85",
+ "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -977,20 +927,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
-dependencies = [
- "bytes",
- "prost 0.10.4",
+ "syn",
 ]
 
 [[package]]
@@ -999,7 +939,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
- "prost 0.13.3",
+ "prost",
 ]
 
 [[package]]
@@ -1049,7 +989,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1062,7 +1002,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1213,7 +1153,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1229,12 +1169,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1265,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -1285,7 +1234,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1299,15 +1248,15 @@ dependencies = [
  "float-pretty-print",
  "glob",
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools",
  "jsonschema",
  "num-derive",
  "num-traits",
  "once_cell",
  "percent-encoding",
- "prost 0.10.4",
- "prost-build 0.10.4",
- "prost-types 0.10.1",
+ "prost",
+ "prost-build",
+ "prost-types",
  "regex",
  "semver",
  "serde_json",
@@ -1338,7 +1287,7 @@ version = "0.0.11"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1346,22 +1295,11 @@ name = "substrait-validator-py"
 version = "0.0.11"
 dependencies = [
  "dunce",
- "prost-build 0.13.3",
+ "prost-build",
  "pyo3",
  "pyo3-build-config",
  "substrait-validator",
  "walkdir",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1395,32 +1333,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-runner"
 version = "0.0.11"
 dependencies = [
  "glob",
- "prost-build 0.10.4",
+ "prost-build",
  "rayon",
  "serde",
  "serde_json",
  "substrait-validator",
  "walkdir",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -1439,7 +1362,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]
 
 [[package]]
@@ -1489,11 +1412,36 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1557,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,7 +1572,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1640,7 +1594,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1650,18 +1604,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"
@@ -1786,6 +1728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,5 +1753,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,17 +1004,17 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.3",
+ "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -1022,19 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
-dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
+checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1042,19 +1032,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
 dependencies = [
  "libc",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1064,13 +1054,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config 0.21.2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.85",
 ]
@@ -1358,7 +1348,7 @@ dependencies = [
  "dunce",
  "prost-build 0.13.3",
  "pyo3",
- "pyo3-build-config 0.22.3",
+ "pyo3-build-config",
  "substrait-validator",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -876,6 +876,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,7 +901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -909,11 +929,32 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "regex",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+dependencies = [
+ "bytes",
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
+ "regex",
+ "syn 2.0.85",
+ "tempfile",
 ]
 
 [[package]]
@@ -930,13 +971,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -996,7 +1059,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1009,7 +1072,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config 0.21.2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1160,7 +1223,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1232,7 +1295,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1252,9 +1315,9 @@ dependencies = [
  "num-traits",
  "once_cell",
  "percent-encoding",
- "prost",
- "prost-build",
- "prost-types",
+ "prost 0.10.4",
+ "prost-build 0.10.4",
+ "prost-types 0.10.1",
  "regex",
  "semver",
  "serde_json",
@@ -1285,7 +1348,7 @@ version = "0.0.11"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1293,7 +1356,7 @@ name = "substrait-validator-py"
 version = "0.0.11"
 dependencies = [
  "dunce",
- "prost-build",
+ "prost-build 0.13.3",
  "pyo3",
  "pyo3-build-config 0.22.3",
  "substrait-validator",
@@ -1313,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1355,7 +1418,7 @@ name = "test-runner"
 version = "0.0.11"
 dependencies = [
  "glob",
- "prost-build",
+ "prost-build 0.10.4",
  "rayon",
  "serde",
  "serde_json",
@@ -1386,7 +1449,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1565,7 +1628,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -1587,7 +1650,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1749,5 +1812,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib"]
 doc = false
 
 [build-dependencies]
-cbindgen = "0.26.0"
+cbindgen = "0.27.0"
 
 [dependencies]
 substrait-validator = { path = "../rs", version = "0.0.11" }

--- a/c/build.rs
+++ b/c/build.rs
@@ -5,9 +5,11 @@ use std::env;
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    let mut config = cbindgen::Config::default();
-    config.cpp_compat = true;
-    config.language = cbindgen::Language::C;
+    let mut config = cbindgen::Config {
+        cpp_compat: true,
+        language: cbindgen::Language::C,
+        ..Default::default()
+    };
     config.export.prefix = Some("substrait_validator_".to_string());
     config
         .export

--- a/ci/version-diff-template
+++ b/ci/version-diff-template
@@ -1,5 +1,5 @@
 diff --git a/c/Cargo.toml b/c/Cargo.toml
-index 0e9b476..7165025 100644
+index d8ad49b..4bd02ef 100644
 --- a/c/Cargo.toml
 +++ b/c/Cargo.toml
 @@ -1,6 +1,6 @@
@@ -9,17 +9,18 @@ index 0e9b476..7165025 100644
 +version = "{to}"
  edition = "2021"
  license = "Apache-2.0"
- 
-@@ -12,6 +12,6 @@ doc = false
- cbindgen = "0.26.0"
- 
+
+@@ -12,7 +12,7 @@ doc = false
+ cbindgen = "0.27.0"
+
  [dependencies]
 -substrait-validator = {{ path = "../rs", version = "{frm}" }}
 +substrait-validator = {{ path = "../rs", version = "{to}" }}
  libc = "0.2"
  thiserror = "1.0"
+ once_cell = "1.19"
 diff --git a/derive/Cargo.toml b/derive/Cargo.toml
-index 7a8af00..539e170 100644
+index 1cf1f7e..482c127 100644
 --- a/derive/Cargo.toml
 +++ b/derive/Cargo.toml
 @@ -4,7 +4,7 @@ description = "Procedural macros for substrait-validator"
@@ -30,9 +31,9 @@ index 7a8af00..539e170 100644
 +version = "{to}"
  edition = "2021"
  license = "Apache-2.0"
- 
+
 diff --git a/py/Cargo.toml b/py/Cargo.toml
-index c095a2d..32108ad 100644
+index d28af20..28abfb1 100644
 --- a/py/Cargo.toml
 +++ b/py/Cargo.toml
 @@ -1,6 +1,6 @@
@@ -45,19 +46,19 @@ index c095a2d..32108ad 100644
  include = [
 @@ -29,7 +29,7 @@ name = "substrait_validator"
  doc = false
- 
+
  [dependencies]
 -substrait-validator = {{ path = "../rs", version = "{frm}" }}
 +substrait-validator = {{ path = "../rs", version = "{to}" }}
- pyo3 = {{ version = "0.21.2", features = ["extension-module"] }}
- 
+ pyo3 = {{ version = "0.22.5", features = ["extension-module"] }}
+
  [build-dependencies]
 diff --git a/py/pyproject.toml b/py/pyproject.toml
-index 8481d2c..60d0453 100644
+index 6e602e6..dd144de 100644
 --- a/py/pyproject.toml
 +++ b/py/pyproject.toml
 @@ -5,7 +5,7 @@ backend-path = ["."]
- 
+
  [project]
  name = "substrait-validator"
 -version = "{frm}"
@@ -66,7 +67,7 @@ index 8481d2c..60d0453 100644
  readme = "README.md"
  license = {{ file = "LICENSE" }}
 diff --git a/rs/Cargo.toml b/rs/Cargo.toml
-index 6dbf6a8..d7e0c22 100644
+index 4144f94..791db63 100644
 --- a/rs/Cargo.toml
 +++ b/rs/Cargo.toml
 @@ -4,7 +4,7 @@ description = "Substrait validator"
@@ -78,39 +79,39 @@ index 6dbf6a8..d7e0c22 100644
  edition = "2021"
  license = "Apache-2.0"
  include = ["src", "build.rs", "README.md"]
-@@ -17,7 +17,7 @@ prost-types = "0.10"
- 
+@@ -24,7 +24,7 @@ prost-types = "0.13.3"
+
  # Prost doesn't generate any introspection stuff, so we hack that stuff in with
  # our own procedural macros.
 -substrait-validator-derive = {{ path = "../derive", version = "{frm}" }}
 +substrait-validator-derive = {{ path = "../derive", version = "{to}" }}
- 
+
  # Google/protobuf has a funny idea about case conventions (it converts them all
  # over the place) and prost remaps to Rust's conventions to boot. So, to
 diff --git a/rs/README.md b/rs/README.md
-index 1ea785f..553fd82 100644
+index 14f8216..5d908fe 100644
 --- a/rs/README.md
 +++ b/rs/README.md
 @@ -6,7 +6,7 @@ plans.
- 
+
  ```
  [dependencies]
 -substrait-validator = "{frm}"
 +substrait-validator = "{to}"
  ```
- 
+
  YAML file resolution
 @@ -20,7 +20,7 @@ dependency:
- 
+
  ```
  [dependencies]
 -substrait-validator = {{ version = "{frm}", features = ["curl"] }}
 +substrait-validator = {{ version = "{to}", features = ["curl"] }}
  ```
- 
+
  This adds the `substrait_validator::Config::add_curl_yaml_uri_resolver()`
 diff --git a/tests/Cargo.toml b/tests/Cargo.toml
-index ae095fd..a341e1c 100644
+index cf1ba03..4f6c8d6 100644
 --- a/tests/Cargo.toml
 +++ b/tests/Cargo.toml
 @@ -1,6 +1,6 @@
@@ -123,7 +124,7 @@ index ae095fd..a341e1c 100644
  default-run = "runner"
 @@ -14,7 +14,7 @@ name = "find_protoc"
  path = "src/find_protoc.rs"
- 
+
  [dependencies]
 -substrait-validator = {{ path = "../rs", version = "{frm}" }}
 +substrait-validator = {{ path = "../rs", version = "{to}" }}

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -33,7 +33,7 @@ substrait-validator = { path = "../rs", version = "0.0.11" }
 pyo3 = { version = "0.21.2", features = ["extension-module"] }
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.13.3"
 pyo3-build-config = "0.22.2"
 walkdir = "2"
 dunce = "1"

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -30,7 +30,7 @@ doc = false
 
 [dependencies]
 substrait-validator = { path = "../rs", version = "0.0.11" }
-pyo3 = { version = "0.21.2", features = ["extension-module"] }
+pyo3 = { version = "0.22.5", features = ["extension-module"] }
 
 [build-dependencies]
 prost-build = "0.13.3"

--- a/py/build.rs
+++ b/py/build.rs
@@ -78,7 +78,7 @@ fn main() {
     fs::create_dir_all(&intermediate_path).expect("failed to create protoc output directory");
 
     // Run protoc.
-    let mut cmd = Command::new(prost_build::protoc());
+    let mut cmd = Command::new(prost_build::protoc_from_env());
     for input_path in input_paths.iter() {
         let mut proto_path_arg = OsString::new();
         proto_path_arg.push("--proto_path=");

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -94,6 +94,7 @@ impl Config {
     /// for the complete syntax). If resolve_as is None, the URI will not
     /// be resolved; otherwise it should be a string representing the URI it
     /// should be resolved as.
+    #[pyo3(signature = (pattern, resolve_as = "None"))]
     pub fn override_uri(&mut self, pattern: &str, resolve_as: Option<&str>) -> PyResult<()> {
         let pattern = match ::substrait_validator::Pattern::new(pattern) {
             Ok(p) => p,
@@ -128,6 +129,7 @@ impl Config {
     /// Sets the maximum recursion depth for URI resolution, in the presence of
     /// transitive dependencies. Setting this to None disables the limit,
     /// setting this to zero disables URI resolution entirely.
+    #[pyo3(signature = (depth=None))]
     pub fn set_max_uri_resolution_depth(&mut self, depth: Option<usize>) {
         self.config.set_max_uri_resolution_depth(depth);
     }
@@ -149,6 +151,7 @@ struct ResultHandle {
 #[pymethods]
 impl ResultHandle {
     #[new]
+    #[pyo3(signature = (data, config=None))]
     pub fn new(data: &[u8], config: Option<&Config>) -> Self {
         Self {
             root: if let Some(config) = config {

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,8 +19,8 @@ private_docs = []
 [dependencies]
 
 # Prost is used to deal with protobuf serialization and deserialization.
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.13.3"
+prost-types = "0.13.3"
 
 # Prost doesn't generate any introspection stuff, so we hack that stuff in with
 # our own procedural macros.
@@ -91,7 +91,7 @@ semver = "1.0"
 [build-dependencies]
 
 # Used for generating Rust structs from the protobuf definitions.
-prost-build = "0.10"
+prost-build = "0.13.3"
 
 # Used to automatically find all protobuf files.
 walkdir = "2"

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -148,13 +148,10 @@ main/py/prepare_build.py).
 
 ### Protobuf
 
-In order to rely on as few external dependencies as possible, all protoc
-invocations by the various parts of the build invoke the `protoc` executable
-as found/compiled and exposed by [prost-build](prost-build). That is: this
-protoc is also abused to generate Python bindings. Unfortunately, prost-build
-is planning to [remove](https://github.com/tokio-rs/prost/pull/620) the build
-logic for protoc at the time of writing (and who can blame them), so this will
-need to be done differently in the future.
+Protobuf code generation is done via `prost`, which requires access to a
+`protoc` executable. This will need to be installed on your system while
+developing (e.g. via a package manager). In CI, it is installed as part of the
+Github actions.
     "
 )]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2"
 glob = "0.3"
-prost-build = "0.10"
+prost-build = "0.13.3"
 rayon = "1.10"

--- a/tests/src/find_protoc.rs
+++ b/tests/src/find_protoc.rs
@@ -4,5 +4,5 @@
 //! the Python code as well...
 
 fn main() {
-    println!("{}", prost_build::protoc().display());
+    println!("{}", prost_build::protoc_from_env().display());
 }


### PR DESCRIPTION
This PR updates the `prost{-*}`, `pyo3`, and `cbindgen` dependencies. `pyo3` in particular was causing a build error in other PRs. This PR should now pass all CI.

### Notes

In addition to updating the dependency versions and the code that calls it where necessary, I also found that `protoc` was missing in a number of CI jobs where it seemed to be needed. I'm not sure how this worked before; my best guess was that the generated code was cached and carried over, and updating `prost` changed that.

### Build Error

in particular, this is intended to fix [this error](https://github.com/substrait-io/substrait-validator/actions/runs/11555965622/job/32162579633?pr=281):

```
error: failed to run custom build command for `pyo3-ffi v0.21.2`

Caused by:
  process didn't exit successfully: `/Users/runner/work/substrait-validator/substrait-validator/target/debug/build/pyo3-ffi-77caf4a9541fc18e/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=PYO3_CROSS
  cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
  cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
  cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_IMPLEMENTATION
  cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
  cargo:rerun-if-env-changed=PYO3_USE_ABI3_FORWARD_COMPATIBILITY

  --- stderr
  error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
  = help: please check if an updated version of PyO3 is available. Current version: 0.21.2
  = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
warning: build failed, waiting for other jobs to finish...
```

