### PR TITLE
chore(deps): unlock jsonschema version

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -39,7 +39,7 @@ serde_yaml = "0.9"
 # schema validation with this format this uses serde_json types as input for
 # both the schema and the input, so we need to depend on that as well, even
 # though we don't actually do any JSON serialization and deserialization.
-jsonschema = { version = "=0.18.0", default-features = false }
+jsonschema = { version = "0.18", default-features = false }
 serde_json = "1"
 
 # Used for checking identifier syntax (could be removed if regexes don't end up


### PR DESCRIPTION
This is a small change, to unlock the `jsonschema` version depended on.

For the purposes of substrait-validator, this gives dependents on it a bit more flexibility in which patch version (0.18.0, 0.18.1, …, 0.18.3) they use. The [original reason](https://github.com/substrait-io/substrait-validator/commit/4d81aec8d1ee39cb0021478b8b3b15dd635d9f92) for locking it had to do with an issue that [no longer applies](https://github.com/Stranger6667/jsonschema/pull/357), especially since that was for `0.15.0` vs. `0.15.1` and we've updated to 0.18 since then.

For my purposes, this resolves some local version mismatches, so I'd appreciate it, although of course the PR itself should be of overall benefit to the project.