### PR TITLE
build: fix build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -84,8 +84,12 @@ jobs:
         with:
           command: build
           args: --release -o dist --universal2 -m py/Cargo.toml
+      - name: Fix permissions
+        if: ${{ matrix.type == 'wheel' && matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo chown 1001:1001 -R /home/runner/work/substrait-validator/substrait-validator
       - name: Install runtime dependencies
-        run: python3 -m pip install --upgrade protobuf pytest click pyyaml jdot toml
+        run: python3 -m pip install --upgrade -e "py/[test]"
       - name: Install generated sdist
         if: ${{ matrix.type == 'sdist' }}
         run: python3 -m pip install dist/substrait_validator-*.tar.gz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         run: cargo test
         if: ${{ matrix.os != 'windows-latest' }}
       - name: Install test runner dependencies
-        run: python3 -m pip install --upgrade pip protobuf pyyaml click
+        run: python3 -m pip install --upgrade pip && python3 -m pip install py/
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Run validation tests
         # No need to run validation tests for all operating systems, and Linux

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["protobuf > 3.19.3", "click >= 8", "pyyaml >= 6", "jdot >= 0.5"]
+dependencies = ["protobuf >3.19.3,<7", "click >= 8", "pyyaml >= 6", "jdot >= 0.5"]
 
 [project.optional-dependencies]
 test = ["pytest < 10.0.0", "toml >= 0.10.2"]


### PR DESCRIPTION
- restricts protobuf version to >3.19.3,<7 since protobuf version 7.x drops the `label` field from `FieldDescriptor` which this code depends on https://github.com/protocolbuffers/protobuf/releases/tag/v34.0

> [Python] Remove deprecated FieldDescriptor.label (https://github.com/protocolbuffers/protobuf/commit/0a8ff55518ea5874478ad5b26515b31d186045a9)


- ensures we install the correct PyPI dependency version during Github Actions build
- fixes file system permissions for the Linux based builds 