### PR TITLE
ci(dependabot): add prost group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         applies-to: version-updates
         patterns:
           - "strum*"
+      prost:
+        applies-to: version-updates
+        patterns:
+          - "prost*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
As already identified here:
- https://github.com/substrait-io/substrait-validator/pull/436#pullrequestreview-4003259227
- https://github.com/substrait-io/substrait-validator/pull/435#pullrequestreview-4003259423

the `prost*` dependencies shouldn't be updated in a single PR. This adds a dependabot group for `prost` dependencies similar to the existing `strum` dependency group.