### PR TITLE
ci: make version-diff-template more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,12 @@ members = [
     "py",
     "tests"
 ]
+
+[workspace.package]
+version = "0.1.4"
+edition = "2021"
+license = "Apache-2.0"
+
+[workspace.dependencies]
+substrait-validator = { path = "rs", version = "0.1.4" }
+substrait-validator-derive = { path = "derive", version = "0.1.4" }

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "substrait-validator-c"
-version = "0.1.4"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -16,7 +16,7 @@ protoc = ["substrait-validator/protoc"]
 cbindgen = "0.29.0"
 
 [dependencies]
-substrait-validator = { path = "../rs", version = "0.1.4" }
+substrait-validator = { workspace = true }
 libc = "0.2"
 thiserror = "2.0"
 once_cell = "1.21"

--- a/ci/version-diff-template
+++ b/ci/version-diff-template
@@ -1,60 +1,23 @@
-diff --git a/c/Cargo.toml b/c/Cargo.toml
-index 114b0cc..fc9ce3e 100644
---- a/c/Cargo.toml
-+++ b/c/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "substrait-validator-c"
+diff --git a/Cargo.toml b/Cargo.toml
+index bcfca76..3fbb0a7 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -9,10 +9,10 @@ members = [
+ ]
+
+ [workspace.package]
 -version = "{frm}"
 +version = "{to}"
  edition = "2021"
  license = "Apache-2.0"
 
-@@ -16,7 +16,7 @@ protoc = ["substrait-validator/protoc"]
- cbindgen = "0.29.0"
-
- [dependencies]
--substrait-validator = {{ path = "../rs", version = "{frm}" }}
-+substrait-validator = {{ path = "../rs", version = "{to}" }}
- libc = "0.2"
- thiserror = "2.0"
- once_cell = "1.21"
-diff --git a/derive/Cargo.toml b/derive/Cargo.toml
-index b4ba0fc..7c24520 100644
---- a/derive/Cargo.toml
-+++ b/derive/Cargo.toml
-@@ -4,7 +4,7 @@ description = "Procedural macros for substrait-validator"
- homepage = "https://substrait.io/"
- repository = "https://github.com/substrait-io/substrait-validator"
- readme = "README.md"
--version = "{frm}"
-+version = "{to}"
- edition = "2021"
- license = "Apache-2.0"
-
-diff --git a/py/Cargo.toml b/py/Cargo.toml
-index 1ea9db1..027b71d 100644
---- a/py/Cargo.toml
-+++ b/py/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "substrait-validator-py"
--version = "{frm}"
-+version = "{to}"
- edition = "2018"
- license = "Apache-2.0"
- include = [
-@@ -33,7 +33,7 @@ name = "substrait_validator"
- doc = false
-
- [dependencies]
--substrait-validator = {{ path = "../rs", version = "{frm}" }}
-+substrait-validator = {{ path = "../rs", version = "{to}" }}
- pyo3 = {{ version = "0.27.2", features = ["extension-module"] }}
-
- [build-dependencies]
+ [workspace.dependencies]
+-substrait-validator = {{ path = "rs", version = "{frm}" }}
+-substrait-validator-derive = {{ path = "derive", version = "{frm}" }}
++substrait-validator = {{ path = "rs", version = "{to}" }}
++substrait-validator-derive = {{ path = "derive", version = "{to}" }}
 diff --git a/py/pyproject.toml b/py/pyproject.toml
-index b3b3464..dd144de 100644
+index 95d1031..d3ad41b 100644
 --- a/py/pyproject.toml
 +++ b/py/pyproject.toml
 @@ -5,7 +5,7 @@ backend-path = ["."]
@@ -66,41 +29,10 @@ index b3b3464..dd144de 100644
  description = "Validator for Substrait query plans"
  readme = "README.md"
  license = {{ file = "LICENSE" }}
-diff --git a/rs/Cargo.toml b/rs/Cargo.toml
-index 1f9f762..84f67fa 100644
---- a/rs/Cargo.toml
-+++ b/rs/Cargo.toml
-@@ -4,7 +4,7 @@ description = "Substrait validator"
- homepage = "https://substrait.io/"
- repository = "https://github.com/substrait-io/substrait-validator"
- readme = "README.md"
--version = "{frm}"
-+version = "{to}"
- edition = "2021"
- license = "Apache-2.0"
- include = ["src", "build.rs", "README.md"]
-@@ -29,7 +29,7 @@ prost-types = "0.13.4"
-
- # Prost doesn't generate any introspection stuff, so we hack that stuff in with
- # our own procedural macros.
--substrait-validator-derive = {{ path = "../derive", version = "{frm}" }}
-+substrait-validator-derive = {{ path = "../derive", version = "{to}" }}
-
- # Google/protobuf has a funny idea about case conventions (it converts them all
- # over the place) and prost remaps to Rust's conventions to boot. So, to
 diff --git a/rs/README.md b/rs/README.md
-index afead27..5d908fe 100644
+index 04a001d..b8cb106 100644
 --- a/rs/README.md
 +++ b/rs/README.md
-@@ -6,7 +6,7 @@ plans.
-
- ```
- [dependencies]
--substrait-validator = "{frm}"
-+substrait-validator = "{to}"
- ```
-
- YAML file resolution
 @@ -20,7 +20,7 @@ dependency:
 
  ```
@@ -110,24 +42,3 @@ index afead27..5d908fe 100644
  ```
 
  This adds the `substrait_validator::Config::add_curl_yaml_uri_resolver()`
-diff --git a/tests/Cargo.toml b/tests/Cargo.toml
-index 62d2f87..79cb4d5 100644
---- a/tests/Cargo.toml
-+++ b/tests/Cargo.toml
-@@ -1,6 +1,6 @@
- [package]
- name = "test-runner"
--version = "{frm}"
-+version = "{to}"
- edition = "2018"
- license = "Apache-2.0"
- default-run = "runner"
-@@ -18,7 +18,7 @@ path = "src/find_protoc.rs"
- protoc = ["dep:protobuf-src", "substrait-validator/protoc"]
-
- [dependencies]
--substrait-validator = {{ path = "../rs", version = "{frm}" }}
-+substrait-validator = {{ path = "../rs", version = "{to}" }}
- serde = {{ version = "1.0", features = ["derive"] }}
- serde_json = "1.0"
- walkdir = "2"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -4,9 +4,9 @@ description = "Procedural macros for substrait-validator"
 homepage = "https://substrait.io/"
 repository = "https://github.com/substrait-io/substrait-validator"
 readme = "README.md"
-version = "0.1.4"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrait-validator-py"
-version = "0.1.4"
+version.workspace = true
 edition = "2018"
 license = "Apache-2.0"
 include = [
@@ -33,7 +33,7 @@ name = "substrait_validator"
 doc = false
 
 [dependencies]
-substrait-validator = { path = "../rs", version = "0.1.4" }
+substrait-validator = { workspace = true }
 pyo3 = { version = "0.27.2", features = ["extension-module"] }
 
 [build-dependencies]

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "substrait-validator-py"
 version.workspace = true
-edition = "2018"
-license = "Apache-2.0"
+edition.workspace = true
+license.workspace = true
 include = [
     "/LICENSE",
     "/README.md",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -4,9 +4,9 @@ description = "Substrait validator"
 homepage = "https://substrait.io/"
 repository = "https://github.com/substrait-io/substrait-validator"
 readme = "README.md"
-version = "0.1.4"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 include = ["src", "build.rs", "README.md"]
 
 [features]
@@ -29,7 +29,7 @@ prost-types = "0.14.3"
 
 # Prost doesn't generate any introspection stuff, so we hack that stuff in with
 # our own procedural macros.
-substrait-validator-derive = { path = "../derive", version = "0.1.4" }
+substrait-validator-derive = { workspace = true }
 
 # Google/protobuf has a funny idea about case conventions (it converts them all
 # over the place) and prost remaps to Rust's conventions to boot. So, to

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-runner"
-version = "0.1.4"
+version.workspace = true
 edition = "2018"
 license = "Apache-2.0"
 default-run = "runner"
@@ -18,7 +18,7 @@ path = "src/find_protoc.rs"
 protoc = ["dep:protobuf-src", "substrait-validator/protoc"]
 
 [dependencies]
-substrait-validator = { path = "../rs", version = "0.1.4" }
+substrait-validator = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "test-runner"
 version.workspace = true
-edition = "2018"
-license = "Apache-2.0"
+edition.workspace = true
+license.workspace = true
 default-run = "runner"
 
 [[bin]]


### PR DESCRIPTION
## Solution

This PR:
- centralizes versions and other common fields (`edition`, `license`) in workspace `Cargo.toml`
- simplifies `ci/version-diff-template`

## Context

Currently, we have the problem that the `ci/version-diff-template` is subject to failures when dependency versions change, e.g. #491 updates cbindgen from 0.29.0 to 0.29.2 which breaks the version diff approach: https://github.com/substrait-io/substrait-validator/actions/runs/24321373083/job/71008097045?pr=491

```
Run python3 ci/version.py check
error: patch failed: c/Cargo.toml:16
error: c/Cargo.toml: patch does not apply
Modifying version from 0.1.4 to 3.1.4...
  (dry run, won't actually make the change)
Patch is invalid. Something is out of sync: check the version
file and try regenerating the patch template.
Error: Process completed with exit code 1.
```

The reason is that the `cbindgen` version is included as `0.29.0` in the `ci/version-diff-template` and if it changes as in #491 the diff does not match anymore:

https://github.com/substrait-io/substrait-validator/blob/5ebc763f093f25edc037a4b2106fccc982766a21/ci/version-diff-template#L1-L21

We can avoid including the child `Cargo.toml` files in the `ci/version-diff-template` by moving the package version and dependency versions into the root workspace `Cargo.toml`. This simplifies the `ci/version-diff-template` and makes it more robust to dependency version changes.