### PR TITLE
build(deps): group substrait-* updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
         applies-to: version-updates
         patterns:
           - "prost*"
+      substrait:
+        applies-to: version-updates
+        patterns:
+          - "substrait*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,3 +27,8 @@ updates:
     directory: "/py"
     schedule:
       interval: "daily"
+    groups:
+      substrait:
+        applies-to: version-updates
+        patterns:
+          - "substrait*"


### PR DESCRIPTION
The `substrait-*` packages (e.g. `substrait-extensions`, `substrait-antlr`) are released together, so bumping them independently produces multiple dependabot PRs (e.g. #535, #536).

This adds a `substrait` group to dependabot so they're collapsed into a single PR per ecosystem:
- **cargo**: groups `substrait-extensions`, `substrait-antlr`, etc.
- **pip** (`/py`): groups `substrait*` as well, for the Python substrait packages being added via separate in-flight PRs.

Note: dependabot grouping is per-ecosystem, so the cargo and pip updates will still arrive as separate (grouped) PRs — they can't be combined into one PR across ecosystems.

🤖 Generated with AI