### PR TITLE
docs: mention CLA requirement for all contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ Contributions are welcome! Here are some ways you can help:
 
 All contributions should be licensed under Apache 2.0. We use SPDX license headers to minimize clutter. CI will ensure that all files have such a header.
 
+Substrait also requires all contributors to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) before their contributions can be merged. A GitHub app checks this on every pull request and guides new contributors through signing it.
+
 ## Development dependencies
 
 Here's a (probably non-exhaustive) list of things you may want to have installed to develop for the validator.


### PR DESCRIPTION
Substrait requires every contributor to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait), and CLA Assistant enforces this as a `license/cla` status check on every pull request in this repository. Nothing in `CONTRIBUTING.md` mentioned it, so contributors only learned about the requirement from the check appearing on their PR — the confusing first contact described in substrait-io/substrait#630.

Add it to the existing **Licensing** section, which already covers the Apache 2.0 and SPDX header requirements, using the wording already carried by [`substrait-rs`](https://github.com/substrait-io/substrait-rs/blob/main/CONTRIBUTING.md).

Companion to substrait-io/substrait#1170, which covers the specification repository's website and `CONTRIBUTING.md`.

See substrait-io/substrait#630

🤖 Generated with AI
